### PR TITLE
Fix: crash NPE with null handler retrieved on dismiss

### DIFF
--- a/cookiebar2/src/main/java/org/aviran/cookiebar2/Cookie.java
+++ b/cookiebar2/src/main/java/org/aviran/cookiebar2/Cookie.java
@@ -272,7 +272,7 @@ final class Cookie extends LinearLayout implements View.OnTouchListener {
     public void dismiss(final CookieBarDismissListener listener) {
         @NonNull Handler viewHandler = getHandler();
         if (viewHandler != null) {
-            getHandler().removeCallbacksAndMessages(null);
+            viewHandler.removeCallbacksAndMessages(null);
         }
         if(listener != null) {
             dismissListener = listener;

--- a/cookiebar2/src/main/java/org/aviran/cookiebar2/Cookie.java
+++ b/cookiebar2/src/main/java/org/aviran/cookiebar2/Cookie.java
@@ -3,6 +3,7 @@ package org.aviran.cookiebar2;
 import android.animation.Animator;
 import android.content.Context;
 import android.graphics.Color;
+import android.os.Handler;
 import android.support.annotation.AttrRes;
 import android.support.annotation.LayoutRes;
 import android.support.annotation.NonNull;
@@ -269,7 +270,10 @@ final class Cookie extends LinearLayout implements View.OnTouchListener {
     }
 
     public void dismiss(final CookieBarDismissListener listener) {
-        getHandler().removeCallbacksAndMessages(null);
+        @NonNull Handler viewHandler = getHandler();
+        if (viewHandler != null) {
+            getHandler().removeCallbacksAndMessages(null);
+        }
         if(listener != null) {
             dismissListener = listener;
         }

--- a/cookiebar2/src/main/java/org/aviran/cookiebar2/CookieBar.java
+++ b/cookiebar2/src/main/java/org/aviran/cookiebar2/CookieBar.java
@@ -99,8 +99,13 @@ public class CookieBar {
                 ((Cookie) child).dismiss(new CookieBarDismissListener() {
                     @Override
                     public void onDismiss(int dismissType) {
-                        if(dismissListener != null) {
+                        if (dismissListener != null) {
                             dismissListener.onDismiss(DismissType.REPLACE_DISMISS);
+                        }
+                        // check cookie if attached
+                        if (cookie.getParent() != null) {
+                            ViewGroup parentExist = (ViewGroup) cookie.getParent();
+                            parentExist.removeView(cookie);
                         }
                         parent.addView(cookie);
                     }
@@ -198,11 +203,10 @@ public class CookieBar {
         /**
          * Sets cookie position
          *
-         * @deprecated As of CookieBar2 1.1.0, use
-         *             {@link #setCookiePosition(int)} instead.
-
          * @param layoutGravity Cookie position, use either CookieBar.TOP or CookieBar.BOTTOM
          * @return builder
+         * @deprecated As of CookieBar2 1.1.0, use
+         * {@link #setCookiePosition(int)} instead.
          */
         @Deprecated
         public Builder setLayoutGravity(int layoutGravity) {


### PR DESCRIPTION
```
java.lang.NullPointerException: Attempt to invoke virtual method 'void android.os.Handler.removeCallbacksAndMessages(java.lang.Object)' on a null object reference
    m.a.a.a.a(Cookie.java:76)
    m.a.a.a.a(Cookie.java:75)
    m.a.a.a$b$a.run(Cookie.java:2)
    android.os.Handler.handleCallback(Handler.java:907)
    android.os.Handler.dispatchMessage(Handler.java:105)
    android.os.Looper.loop(Looper.java:216)
    android.app.ActivityThread.main(ActivityThread.java:7625)
java.lang.reflect.Method.invoke(Native Method)
    com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:524)
    com.android.internal.os.ZygoteInit.main(ZygoteInit.java:987)
```
